### PR TITLE
chore: merge develop into main (hotfix: py312 compatibility)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 annotated-doc==0.0.4
 annotated-types==0.7.0
 anyio==4.12.1
-audioop-lts==0.2.2
+audioop-lts==0.2.2; python_version >= "3.13"
 audioread==3.1.0
 certifi==2026.1.4
 cffi==2.0.0
@@ -59,9 +59,9 @@ sniffio==1.3.1
 soundfile==0.13.1
 soxr==1.0.0
 stable-ts==2.19.1
-standard-aifc==3.13.0
-standard-chunk==3.13.0
-standard-sunau==3.13.0
+standard-aifc==3.13.0; python_version >= "3.13"
+standard-chunk==3.13.0; python_version >= "3.13"
+standard-sunau==3.13.0; python_version >= "3.13"
 starlette==0.50.0
 sympy==1.14.0
 tenacity==9.1.2


### PR DESCRIPTION
This PR merges the hotfix for Python 3.12 compatibility from develop to main.