### PR TITLE
[Phase 1] Multi-Mode 아키텍처 개편 및 전략 패턴 도입

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ debug_transcribe.py
 # User Custom Config
 data/config.json
 
+Expansion_Plan.md
+Dev_Plan.md

--- a/main.py
+++ b/main.py
@@ -133,6 +133,7 @@ async def update_settings(req: SettingsUpdateRequest):
 class SummaryRequest(BaseModel):
     filename: str
     custom_title: Optional[str] = None
+    mode: Optional[str] = "sermon" # [New] 분석 모드 (sermon, humor 등)
 
 class BlogGenerationRequest(BaseModel):
     filename: str
@@ -469,7 +470,8 @@ async def run_summary_pipeline(task_id: str, req: SummaryRequest):
                 segments, 
                 req.filename, 
                 custom_title=req.custom_title,
-                status_callback=summarizer_callback
+                status_callback=summarizer_callback,
+                mode=req.mode # [New] 모드 전달
             )
         )
         

--- a/services/modes/humor.json
+++ b/services/modes/humor.json
@@ -1,0 +1,56 @@
+{
+  "mode_name": "HUMOR_CHAT",
+  "description": "예능, 토크쇼, 하이라이트 중심 편집 모드",
+  "system_instruction": "당신은 베테랑 영상 편집자이자 스토리텔러입니다. 대본을 분석하여 시청자가 이탈하지 않는 10분 내외의 '알짜배기' 하이라이트 편집안을 JSON으로 출력하세요.\n\n**[편집 철학]**\n1. 텍스트보다 에너지를 우선하라: 대사가 없어도 정황상 웃음이 터지거나 리액션이 큰 곳이 센터다.\n2. 지루함은 죄악이다: 주제가 중복되면 가장 텐션 높은 한 문장만 남기고 나머지는 과감히 제거하라.\n3. 서사적 연결: 사소한 발언(Setup)이 나중에 벌어질 사건(Payoff)과 연결된다면 그 빌드업 구간을 반드시 보존하라.\n\n**[분류 규칙]**\n1. Hook: 영상의 가장 강력한 하이라이트 (인트로 선공개용).\n2. Setup: 나중에 터질 웃음이나 사건을 위한 밑밥 구간.\n3. Funny_Moment: 에너지 피크, 티키타카, 반전이 일어나는 구간.\n4. Reaction: 사건에 대한 출연자들의 리액션 중심 구간.\n5. Tangent: 주제에서 벗어난 잡담 (삭제 1순위).\n\n**[작성 가이드라인]**\n- 단순히 시간 순으로 요약하지 말고, 시청자의 호흡을 고려하여 '편집 가이드(edit_guide)'를 상세히 작성하세요.",
+  "response_schema": {
+    "type": "ARRAY",
+    "items": {
+      "type": "OBJECT",
+      "properties": {
+        "title": {
+          "type": "STRING",
+          "description": "장면의 핵심 제목"
+        },
+        "type": {
+          "type": "STRING",
+          "enum": [
+            "Hook",
+            "Setup",
+            "Funny_Moment",
+            "Reaction",
+            "Tangent"
+          ]
+        },
+        "energy_level": {
+          "type": "INTEGER",
+          "minimum": 1,
+          "maximum": 5,
+          "description": "해당 구간의 텐션 (1:정적, 5:폭발)"
+        },
+        "edit_guide": {
+          "type": "STRING",
+          "description": "편집자를 위한 구체적 지시 (예: '여기서 줌인', '음악 중단')"
+        },
+        "summary": {
+          "type": "STRING",
+          "description": "내용 요약"
+        },
+        "start_id": {
+          "type": "INTEGER"
+        },
+        "end_id": {
+          "type": "INTEGER"
+        }
+      },
+      "required": [
+        "title",
+        "type",
+        "energy_level",
+        "edit_guide",
+        "summary",
+        "start_id",
+        "end_id"
+      ]
+    }
+  }
+}

--- a/services/modes/sermon.json
+++ b/services/modes/sermon.json
@@ -1,0 +1,49 @@
+{
+  "mode_name": "SERMON",
+  "description": "설교 영상 전문 분석 모드",
+  "system_instruction": "당신은 설교 영상 전문 미디어 팀장입니다. 제공된 대본을 분석하여 '1차 컷편집(Rough Cut)'을 위한 기획안을 JSON으로 출력하세요.\n목표: 편집자가 불필요한 구간을 빠르게 제거하고, 핵심 구간(예화, 강조점)을 찾아낼 수 있도록 돕는 것.\n\n**[분류 규칙]**\n1. Intro_Icebreak: 설교 전 인사, 가벼운 대화, 날씨 이야기 등.\n2. Scripture: 성경 본문 봉독 구간. (정확한 시작과 끝 지점 포착 필수)\n3. Preaching_Main: 본문 해석, 교리 설명 등 설교의 메인 흐름.\n4. Illustration: 시청자의 몰입을 돕는 예화, 에피소드, 유머 구간. (중요: 별도 챕터로 분리하여 하이라이트화)\n5. Application: 성도들을 향한 삶의 권면, 핵심 메시지 선포, 결단.\n6. Announcement: 교회 광고, 캠페인, 내빈 소개 등. (편집 시 삭제 1순위 후보)\n7. Prayer: 마무리 기도, 축도.\n\n**[작성 가이드라인]**\n- 영상의 처음(ID:1)부터 끝까지 빈틈없이 나누세요.\n- 'Announcement' 구간을 아주 정밀하게 분리하세요. 유튜브 업로드 시 이 구간을 잘라내는 것이 편집자의 주된 업무입니다.\n- 모든 텍스트는 한국어로 작성하세요.",
+  "response_schema": {
+    "type": "ARRAY",
+    "items": {
+      "type": "OBJECT",
+      "properties": {
+        "title": {
+          "type": "STRING",
+          "description": "내용을 직관적으로 알 수 있는 챕터 제목 (예: '예화: 탕자의 비유')"
+        },
+        "type": {
+          "type": "STRING",
+          "enum": [
+            "Intro_Icebreak",
+            "Scripture",
+            "Preaching_Main",
+            "Illustration",
+            "Application",
+            "Announcement",
+            "Prayer"
+          ],
+          "description": "편집 작업을 위한 구간 성격 분류"
+        },
+        "summary": {
+          "type": "STRING",
+          "description": "편집자가 내용을 파악할 수 있는 핵심 내용 요약"
+        },
+        "start_id": {
+          "type": "INTEGER",
+          "description": "시작 세그먼트 ID"
+        },
+        "end_id": {
+          "type": "INTEGER",
+          "description": "종료 세그먼트 ID"
+        }
+      },
+      "required": [
+        "title",
+        "type",
+        "summary",
+        "start_id",
+        "end_id"
+      ]
+    }
+  }
+}

--- a/services/prompts.py
+++ b/services/prompts.py
@@ -1,0 +1,47 @@
+import json
+import os
+
+class PromptFactory:
+    """
+    VideoMode에 따른 시스템 지침 및 JSON Schema를 동적으로 주입하는 팩토리 클래스.
+    """
+    MODES_DIR = os.path.join(os.path.dirname(__file__), "modes")
+
+    @classmethod
+    def get_mode_config(cls, mode_name: str = "sermon") -> dict:
+        """
+        주어진 모드 이름에 해당하는 설정(JSON)을 로드합니다.
+        기본값은 'sermon'입니다.
+        """
+        file_name = f"{mode_name.lower()}.json"
+        file_path = os.path.join(cls.MODES_DIR, file_name)
+
+        if not os.path.exists(file_path):
+            print(f"[PromptFactory] Warning: Mode '{mode_name}' not found. Falling back to 'sermon'.")
+            file_path = os.path.join(cls.MODES_DIR, "sermon.json")
+
+        try:
+            with open(file_path, "r", encoding="utf-8") as f:
+                return json.load(f)
+        except Exception as e:
+            print(f"[PromptFactory] Error loading mode config: {e}")
+            return {}
+
+    @classmethod
+    def create_summarize_prompt(cls, segments: list[dict], mode_name: str = "sermon") -> tuple[str, dict]:
+        """
+        모드에 따른 시스템 지시문과 스키마를 반환합니다.
+        
+        Returns:
+            (system_instruction, response_schema, script_text)
+        """
+        config = cls.get_mode_config(mode_name)
+        
+        # 스크립트 데이터 포맷팅
+        lines = [f"{seg['id']} | {seg['text']}" for seg in segments]
+        script_text = "\n".join(lines)
+        
+        system_instruction = config.get("system_instruction", "")
+        response_schema = config.get("response_schema", {})
+
+        return system_instruction, response_schema, script_text

--- a/services/summarizer.py
+++ b/services/summarizer.py
@@ -87,6 +87,7 @@ class ChapterHealer:
         return healed
 
 from services.system_manager import ConfigManager
+from services.prompts import PromptFactory
 
 # --- [Main Class] Video Summarizer ---
 class VideoSummarizer:
@@ -102,29 +103,6 @@ class VideoSummarizer:
     def _get_model(self, task_type):
         """설정 매니저를 통해 실시간으로 모델명을 가져옵니다."""
         return ConfigManager.get_model(task_type)
-
-    def _create_prompt(self, segments: list[dict]) -> str:
-        """LLM에게 전달할 경량화된 스크립트 데이터를 생성합니다.
-
-        Args:
-            segments: 분석된 자막 세그먼트 리스트.
-
-        Returns:
-            ID와 텍스트가 결합된 문자열 형태의 스크립트 데이터.
-        """
-        lines = [f"{seg['id']} | {seg['text']}" for seg in segments]
-        script_text = "\n".join(lines)
-        
-        system_instruction = (
-            "당신은 영상 콘텐츠 분석가입니다. 대본(Script)을 정밀 분석하여 논리적인 '챕터(Chapter)'로 구분하세요.\n"
-            "반드시 아래 **Markdown 형식**으로만 출력해야 합니다.\n"
-            "## 챕터 제목\n"
-            "- 요약: (상세 서술)\n"
-            "- 구간: [시작ID - 종료ID]\n\n"
-            "조건 1: 영상의 처음(ID:1)부터 끝까지 빈틈없이 나누세요.\n"
-            "조건 2: 요약은 구체적인 행동과 상황을 포함하여 서술하세요."
-        )
-        return f"{system_instruction}\n\n[Script Data]:\n{script_text}"
 
     def _create_blog_prompt(self, segments: list[dict]) -> str:
         """블로그 포스트 생성을 위한 프롬프트를 생성합니다.
@@ -337,7 +315,8 @@ class VideoSummarizer:
         segments: list[dict], 
         video_filename: str, 
         custom_title: str = None, 
-        status_callback: callable = None
+        status_callback: callable = None,
+        mode: str = "sermon"
     ) -> dict:
         """Gemini API의 JSON Mode를 사용하여 자막을 분석하고 챕터 정보를 생성합니다. (Retry 적용)
 
@@ -346,6 +325,7 @@ class VideoSummarizer:
             video_filename: 원본 영상 파일명.
             custom_title: 사용자가 지정한 영상 제목 (선택 사항).
             status_callback: 진행 상태를 보고할 콜백 함수 (선택 사항).
+            mode: 분석 모드 (sermon, humor 등)
 
         Returns:
             요약 결과, 챕터 리스트, 토큰 사용량 등이 포함된 결과 딕셔너리.
@@ -356,51 +336,13 @@ class VideoSummarizer:
         total_lines = len(segments)
         if total_lines == 0: return {"error": "Empty segments"}
 
-        print(f"--- [Summarizer] Analyzing {total_lines} lines with Gemini (JSON Mode) ---")
-        if status_callback: status_callback("Gemini가 내용을 정밀 분석 중 (JSON Mode)...")
+        print(f"--- [Summarizer] Analyzing {total_lines} lines with Gemini ({mode.upper()} Mode) ---")
+        if status_callback: status_callback(f"Gemini가 내용을 분석 중 ({mode.upper()} 모드)...")
 
         tracker = UsageTracker()
         
-        # 프롬프트 구성
-        lines = [f"{seg['id']} | {seg['text']}" for seg in segments]
-        script_text = "\n".join(lines)
-        
-        # JSON 스키마 정의
-        response_schema = {
-            "type": "ARRAY",
-            "items": {
-                "type": "OBJECT",
-                "properties": {
-                    "title": {"type": "STRING", "description": "내용을 직관적으로 알 수 있는 챕터 제목 (예: '예화: 탕자의 비유')"},
-                    "type": {
-                        "type": "STRING", 
-                        "enum": ["Intro_Icebreak", "Scripture", "Preaching_Main", "Illustration", "Application", "Announcement", "Prayer"],
-                        "description": "편집 작업을 위한 구간 성격 분류"
-                    },
-                    "summary": {"type": "STRING", "description": "편집자가 내용을 파악할 수 있는 핵심 내용 요약"},
-                    "start_id": {"type": "INTEGER", "description": "시작 세그먼트 ID"},
-                    "end_id": {"type": "INTEGER", "description": "종료 세그먼트 ID"}
-                },
-                "required": ["title", "type", "summary", "start_id", "end_id"]
-            }
-        }
-
-        system_instruction = (
-            "당신은 설교 영상 전문 미디어 팀장입니다. 제공된 대본을 분석하여 '1차 컷편집(Rough Cut)'을 위한 기획안을 JSON으로 출력하세요.\n"
-            "목표: 편집자가 불필요한 구간을 빠르게 제거하고, 핵심 구간(예화, 강조점)을 찾아낼 수 있도록 돕는 것.\n\n"
-            "**[분류 규칙]**\n"
-            "1. Intro_Icebreak: 설교 전 인사, 가벼운 대화, 날씨 이야기 등.\n"
-            "2. Scripture: 성경 본문 봉독 구간. (정확한 시작과 끝 지점 포착 필수)\n"
-            "3. Preaching_Main: 본문 해석, 교리 설명 등 설교의 메인 흐름.\n"
-            "4. Illustration: 시청자의 몰입을 돕는 예화, 에피소드, 유머 구간. (중요: 별도 챕터로 분리하여 하이라이트화)\n"
-            "5. Application: 성도들을 향한 삶의 권면, 핵심 메시지 선포, 결단.\n"
-            "6. Announcement: 교회 광고, 캠페인, 내빈 소개 등. (편집 시 삭제 1순위 후보)\n"
-            "7. Prayer: 마무리 기도, 축도.\n\n"
-            "**[작성 가이드라인]**\n"
-            "- 영상의 처음(ID:1)부터 끝까지 빈틈없이 나누세요.\n"
-            "- 'Announcement' 구간을 아주 정밀하게 분리하세요. 유튜브 업로드 시 이 구간을 잘라내는 것이 편집자의 주된 업무입니다.\n"
-            "- 모든 텍스트는 한국어로 작성하세요."
-        )
+        # Prompt Factory를 통한 동적 프롬프트 생성
+        system_instruction, response_schema, script_text = PromptFactory.create_summarize_prompt(segments, mode)
 
         try:
             client = genai.Client(api_key=self.api_key)
@@ -419,35 +361,43 @@ class VideoSummarizer:
             # JSON 파싱
             final_chapters = json.loads(response.text)
             
-            # ID -> Time 매핑 & 챕터 제목 정제
+            # ID -> Time 매핑 & 챕터 정보 정제
             mapped_result = []
             for chap in final_chapters:
-                s_idx = max(0, min(chap['start_id'] - 1, total_lines - 1))
-                e_idx = max(0, min(chap['end_id'] - 1, total_lines - 1))
+                s_id = chap.get('start_id', 1)
+                e_id = chap.get('end_id', total_lines)
+                
+                s_idx = max(0, min(s_id - 1, total_lines - 1))
+                e_idx = max(0, min(e_id - 1, total_lines - 1))
                 
                 start_time = segments[s_idx]['start']
                 end_time = segments[e_idx]['end']
                 
-                # 챕터 제목 내 불필요한 마크다운(**, __) 제거
-                clean_chapter_title = re.sub(r'\*\*|__', '', chap['title']).strip()
-                
-                mapped_result.append({
-                    "title": clean_chapter_title,
-                    "type": chap['type'],
-                    "summary": chap['summary'],
+                # 공통 필드 매핑
+                clean_chapter = {
+                    "title": re.sub(r'\*\*|__', '', chap.get('title', '제목 없음')).strip(),
+                    "summary": chap.get('summary', ''),
                     "time": {
                         "start": start_time,
                         "end": end_time,
                         "start_formatted": self._format_time(start_time),
                         "end_formatted": self._format_time(end_time)
                     }
-                })
+                }
+                
+                # 모드별 추가 필드 유지 (예: type, energy_level, edit_guide)
+                for key, value in chap.items():
+                    if key not in ['start_id', 'end_id', 'title', 'summary']:
+                        clean_chapter[key] = value
+                
+                mapped_result.append(clean_chapter)
 
             display_title = custom_title if custom_title and custom_title.strip() else video_filename
 
             result_data = {
                 "video_source": video_filename,
                 "video_title": display_title,
+                "mode": mode,
                 "total_chapters": len(mapped_result),
                 "token_usage": tracker.get_report(),
                 "chapters": mapped_result

--- a/tests/test_summarizer_refactor.py
+++ b/tests/test_summarizer_refactor.py
@@ -1,0 +1,42 @@
+import os
+import json
+import traceback
+from services.summarizer import VideoSummarizer
+
+def test_summarizer_modes():
+    """리팩토링된 Summarizer가 다양한 모드를 지원하는지 테스트"""
+    summ = VideoSummarizer(output_dir="static/results")
+    
+    dummy_segments = [
+        {"id": 1, "start": 0.0, "end": 5.0, "text": "반갑습니다. 오늘은 웃긴 영상을 분석해볼게요."},
+        {"id": 2, "start": 5.0, "end": 10.0, "text": "갑자기 사람이 넘어집니다. ㅋㅋㅋ"},
+        {"id": 3, "start": 10.0, "end": 15.0, "text": "정말 웃기네요. 구독 부탁드립니다."}
+    ]
+
+    # 1. Sermon 모드 테스트
+    print("\n--- Testing SERMON Mode ---")
+    try:
+        res_sermon = summ.summarize(dummy_segments, "test_sermon.mp4", mode="sermon")
+        print(f"Sermon Result Mode: {{res_sermon.get('mode')}}")
+        assert res_sermon.get('mode') == "sermon"
+    except Exception:
+        print("Sermon Test Error:")
+        traceback.print_exc()
+
+    # 2. Humor 모드 테스트
+    print("\n--- Testing HUMOR Mode ---")
+    try:
+        res_humor = summ.summarize(dummy_segments, "test_humor.mp4", mode="humor")
+        print(f"Humor Result Mode: {{res_humor.get('mode')}}")
+        assert res_humor.get('mode') == "humor"
+        if res_humor.get('chapters'):
+            print(f"First chapter sample: {{res_humor['chapters'][0].keys()}}")
+    except Exception:
+        print("Humor Test Error:")
+        traceback.print_exc()
+
+if __name__ == "__main__":
+    if not os.getenv("GOOGLE_API_KEY"):
+        print("Skip test: GOOGLE_API_KEY not found in environment.")
+    else:
+        test_summarizer_modes()


### PR DESCRIPTION
## 💡 변경 사항
- 하드코딩된 설교 요약 로직을  하위 JSON 프로필로 분리하였습니다.
- 를 도입하여 선택된 모드에 따라 LLM 시스템 지시문과 JSON Schema를 동적으로 주입합니다.
- 를 리팩토링하여 새로운 모드(예: HUMOR) 추가 시 코드 수정 없이 대응 가능하도록 개선했습니다.
-  분석 API에  파라미터를 추가했습니다.

## 🧪 테스트 및 CI
- [x] 로컬 테스트 통과 ( 실행 결과 SERMON/HUMOR 모드 정상 작동 확인)
- [x] MacOS(Apple Silicon) 가상환경에서의 동작 확인
- (참고: 와 테스트 결과 파일은 .gitignore 처리됨)