### PR TITLE
[Fix]: 동영상 구간 자르기 중간 구간 오디오 유실 버그 수정

### DIFF
--- a/implementation_plan.md
+++ b/implementation_plan.md
@@ -1,107 +1,77 @@
-# 크로스 플랫폼 및 동적 AI 모델 설정 구현 계획서
+# [버그 수정] 동영상 구간 자르기 시 두 번째(중간 구간) 내보내기부터 오디오(소리) 유실되는 버그 해결 계획
 
-윈도우(Windows) 및 리눅스(Linux) 환경에서 크로스 플랫폼(Cross-platform) 지원이 강화됨에 따라, 프론트엔드 설정 창에서 맥 전용(MLX) 모델로 하드코딩(Hard-coded)되어 있는 Whisper 모델 목록과 권장 설명 문구를 현재 OS 환경에 맞춰 동적으로 노출되도록 보완하고, Google Gemini API를 직접 조회하여 최신 Gemini 및 Gemma 추천 모델 목록을 실시간으로 동적 갱신할 수 있도록 구조를 개선하는 구현 계획서입니다.
+동영상 구간 잘라내기(Export) 기능을 사용할 때, 첫 번째 내보내기(영상 시작점인 0초 부근을 포함하는 경우)에는 소리가 정상적으로 포함되지만, 두 번째 내보내기(영상 중간 구간을 자르는 경우)부터는 오디오 스트림은 존재하나 소리가 완전히 안 나오는(무음, -91dB) 현상이 발생합니다.
 
----
+## User Review Required
 
-## 1. 문제 정의 (Problem Definition)
+> [!NOTE]
+> 본 수정은 FFmpeg 명령어 내부의 `-ss`와 `-to` 옵션의 배치 순서 및 옵션 정의를 변경합니다.
+> 기존에 입력 파일(`-i`) 뒤에 두었던 **출력 옵션** 방식에서, 입력 파일 앞쪽으로 배치하는 **입력 옵션** 방식으로 변경합니다. 
+> 이와 동시에 `-to` 대신 **길이(Duration)**를 지정하는 `-t` 옵션으로 전환하여 FFmpeg 버전에 관계없이 정확한 프레임 이동(Seek)과 오디오 필터 타임라인 일치를 확보합니다.
+> 이 변경은 비디오 인코딩 속도를 대폭 개선하며 프레임 정확도는 그대로 유지됩니다.
 
-### 1.1 현상 분석
-* **하드코딩된 Whisper 모델**: 시스템 설정 창을 열면 '🎙️ 음성 인식 (STT)' 모델 설정 목록에 Apple Silicon 전용 가속 라이브러리인 `mlx-community/...` 형태의 모델만 노출되며, 설명 부분 역시 OS 플랫폼에 무관하게 항상 `(MLX 최적화 모델 권장)`이라고 고정되어 있습니다.
-* **하드코딩된 Gemini 모델**: Gemini 및 Gemma 모델 추천 목록(`GEMINI_MODELS`) 또한 프론트엔드 코드 내에 수동으로 하드코딩되어 있어, Google 측에서 새로운 모델(예: 최신 버전 출시 등)을 업데이트하더라도 코드 수정 없이는 사용자가 최신 모델을 설정 화면에서 선택할 수 없습니다.
+## Proposed Changes
 
-### 1.2 원인 분석
-* **프론트엔드 정적 배열 선언**: `static/js/components.js` 내에 `WHISPER_MODELS` 및 `GEMINI_MODELS` 배열이 특정 모델 리스트로 하드코딩되어 있습니다.
-* **플랫폼 및 최신 API 모델 식별 정보 누락**: 프론트엔드 단에서 현재 동작하고 있는 서버의 운영체제(OS) 정보 및 Google API 측에서 실시간으로 제공하는 사용 가능한 모델 목록을 전달받지 못하고 있습니다.
-* **설정 저장 인터페이스 결합도**: 프론트엔드의 `handleSave` 함수가 API로부터 전달받은 설정 객체 전체(`settings` 상태)를 `/api/settings`에 그대로 `POST` 전송하므로, 백엔드 GET API의 응답 포맷 확장 시 Pydantic 검증 오류가 발생할 우려가 있습니다.
+### Video Processing Service
 
----
+#### [MODIFY] [services/clipper.py](file:///home/radi/cli/summarize_video/services/clipper.py)
+- `cut_video` 메서드 내부의 FFmpeg 명령어 리스트(`cmd`) 구성을 변경합니다.
+- `duration = end_sec - start_sec` 값을 구한 뒤, `-ss`와 `-t`를 `-i` 앞에 추가합니다.
+- 기존 `-i input_path -ss start -to end` 순서에서 `-ss start -t duration -i input_path` 순서로 마이그레이션합니다.
 
-## 2. 제안하는 변경 사항 (Proposed Changes)
+```diff
+@@ -80,48 +80,49 @@
+         output_path = os.path.join(self.temp_dir, output_filename)
+         
+         # 잘라낼 영상의 길이 (진행률 분모)
+         duration = end_sec - start_sec
+         if duration <= 0: duration = 1 # 0으로 나누기 방지
+ 
+         # [FFmpeg Filter Configuration]
+         # 오디오 페이드 적용 (시작 0.1초 인, 종료 0.2초 아웃)
+         fade_duration_in = 0.1
+         fade_duration_out = 0.2
+         audio_filter = f"afade=t=in:st=0:d={fade_duration_in},afade=t=out:st={duration - fade_duration_out}:d={fade_duration_out}"
+ 
+         # [FFmpeg Encoder & Quality Configuration]
+         # OS 및 그래픽 카드 가속 여부에 따른 인코더 설정
+         if self._is_nvenc_available():
+             # NVIDIA NVENC 가속 사용 (Windows / Linux 공용)
+             encoder = "h264_nvenc"
+             quality_opts = ["-rc", "vbr", "-cq", "24", "-preset", "p4"]
+         elif sys.platform == 'darwin':
+             # macOS: Apple Silicon 가속 사용
+             encoder = "h264_videotoolbox"
+             quality_opts = ["-q:v", "65"]
+         else:
+             # Linux 및 기타 OS: CPU 기반 범용 libx264 사용
+             encoder = "libx264"
+             quality_opts = ["-crf", "23", "-preset", "medium"]
+ 
+         # [FFmpeg Command Configuration]
+         cmd = [
+             "ffmpeg", 
+             "-nostdin",
+-            "-i", input_path,
+-            "-ss", str(start_sec),
+-            "-to", str(end_sec),
++            "-ss", str(start_sec),
++            "-t", str(duration),
++            "-i", input_path,
+             "-filter_complex", f"[0:a]{audio_filter}[af]", # 오디오 필터 적용
+             "-map", "0:v", "-map", "[af]",                 # 비디오는 그대로, 오디오는 필터 거친 것 사용
+             "-c:v", encoder,                               # 자동 선택된 인코더
+         ]
+```
 
-문제를 해결하기 위해 백엔드 설정 조회 API가 현재 시스템의 플랫폼 정보, 플랫폼별 권장 Whisper 모델 목록, 그리고 Google API 조회를 통해 얻은 최신 Gemini 및 Gemma 모델 목록을 함께 반환하도록 구조를 확장하고, 프론트엔드가 이를 받아 동적으로 렌더링하고 유연하게 저장하도록 수정합니다.
+## Verification Plan
 
-### 2.1 [MODIFY] [system_manager.py](file:///home/radi/cli/summarize_video/services/system_manager.py)
-* `ConfigManager` 클래스에 각 플랫폼에 맞는 권장 Whisper 모델 목록을 정의합니다:
-  ```python
-  # macOS (darwin) 추천 모델 목록
-  DARWIN_WHISPER_MODELS = [
-      "mlx-community/whisper-large-v3-turbo-q4",
-      "mlx-community/whisper-large-v3-mlx-4bit"
-  ]
-  # Windows/Linux (Faster-Whisper) 추천 모델 목록
-  OTHER_WHISPER_MODELS = [
-      "large-v3-turbo",
-      "large-v3",
-      "medium",
-      "small"
-  ]
-  ```
-* Google GenAI API를 사용하여 사용 가능한 Gemini 및 Gemma 모델 목록을 동적으로 조회하는 `get_gemini_models()` 클래스 메서드를 추가합니다:
-  - `google.genai` SDK의 `client.models.list()`를 호출합니다.
-  - 응답 데이터에서 `models/` 접두사를 정제하고, `gemini` 또는 `gemma` 키워드가 들어간 모델만 필터링합니다.
-  - **인메모리 캐싱(In-memory Caching)**: 매번 네트워크 호출을 방지하기 위해 간단한 클래스 수준 캐시 기법을 적용합니다.
-  - **예외 처리 및 안전 장치(Fallback)**: API Key가 없거나 네트워크 오류가 발생한 경우 미리 지정한 기본 모델 목록(기존 `GEMINI_MODELS` 배열과 동일 구성)을 즉시 반환하여 UI 지연이나 에러를 차단합니다.
+### Automated Tests
+1. 기존 Clipper 유닛 테스트 실행하여 인코더 선택 모킹 로직이 정상 작동하는지 확인합니다.
+   - Command: `./venv/bin/pytest tests/test_clipper.py`
+2. **[신규] 영상 중간 구간 자르기 및 오디오 볼륨 검증 테스트 (`tests/test_clipper_audio_leak.py`)**:
+   - `start_time = 0` (영상 처음)인 경우와 `start_time > 5.0` (영상 중간)인 경우를 모두 테스트하여, 생성된 모든 클립의 오디오 볼륨이 무음($-91.0\text{ dB}$)이 아닌 정상적인 오디오 볼륨 범위(예: $-30\text{ dB} \sim 0\text{ dB}$)를 갖는지 FFmpeg `volumedetect` 필터를 통해 검증하는 자동화 테스트 코드를 구현하고 커밋에 포함합니다.
+   - Command: `./venv/bin/pytest tests/test_clipper_audio_leak.py -s`
 
-### 2.2 [MODIFY] [settings.py](file:///home/radi/cli/summarize_video/app/api/routers/settings.py)
-* `GET /api/settings` 라우터의 응답 데이터를 확장하여 기존 설정(`models` 딕셔너리)뿐만 아니라 현재 구동 서버의 OS 종류(`platform`), 권장 Whisper 모델 목록(`whisper_models`), 그리고 실시간 조회된 `gemini_models`를 추가 메타 정보로 응답하도록 수정합니다.
-  ```json
-  {
-    "models": {
-      "summarizer": "gemini-3.1-flash",
-      "planner": "gemini-3.1-flash-lite",
-      "refiner": "gemma-4-31b-it",
-      "shorts": "gemini-3.1-flash-lite",
-      "whisper": "large-v3-turbo"
-    },
-    "platform": "linux",
-    "whisper_models": [
-      "large-v3-turbo",
-      "large-v3",
-      "medium",
-      "small"
-    ],
-    "gemini_models": [
-      "gemini-2.5-flash",
-      "gemini-2.5-flash-lite",
-      "gemini-2.5-pro",
-      "gemini-3-flash",
-      "gemini-3-pro",
-      "gemini-3-deep-think",
-      "gemma-3-27b-it",
-      "gemma-3-4b-it",
-      "gemma-3-12b-it"
-    ]
-  }
-  ```
-
-### 2.3 [MODIFY] [components.js](file:///home/radi/cli/summarize_video/static/js/components.js)
-* **동적 모델 리스트 바인딩**: 하드코딩된 `WHISPER_MODELS` 및 `GEMINI_MODELS` 배열을 제거하고, `fetchSettings` 실행 시 API 결과물에서 추출한 `whisper_models` 및 `gemini_models` 배열을 React State로 관리하여 드롭다운의 추천 리스트로 동적 바인딩합니다.
-* **설명 문구 동적화**: 백엔드에서 전달받은 `platform` 값이 `"darwin"`인 경우 `(MLX 최적화 모델 권장)`, 그 외의 경우 `(Faster-Whisper 가속 모델 권장)` 등 플랫폼 특이적 설명이 렌더링되도록 삼항 조건식을 작성합니다.
-* **결합도 분리**: `handleSave` 시 설정 데이터 전체를 날리지 않고, 백엔드 요청 스키마(`SettingsUpdateRequest`)에 정합하도록 `{ models: settings.models }` 형태로 가공하여 `POST` 요청을 수행합니다.
-
-### 2.4 [MODIFY] [test_cross_platform.py](file:///home/radi/cli/summarize_video/tests/test_cross_platform.py)
-* `pytest` 테스트 스위트 내에 설정 API(`GET /api/settings`)가 OS 모킹 및 API 클라이언트 모킹 환경 하에서 올바른 `platform` 문자열과 추천 모델 목록(`whisper_models` 및 `gemini_models`)을 통합 반환하는지 유닛 테스트를 보완 및 추가합니다.
-
----
-
-## 3. 검증 계획 (Verification Plan)
-
-### 3.1 자동화 테스트 (Automated Tests)
-* 크로스 플랫폼 시뮬레이션 및 API 응답 스키마 테스트 실행:
-  ```bash
-  ./venv/bin/pytest tests/test_cross_platform.py
-  ```
-
-### 3.2 수동 검증 (Manual Verification)
-1. **Linux/Windows 환경 검증**:
-   - 로컬 웹 서버를 기동하고 브라우저를 열어 우측 상단 설정을 클릭합니다.
-   - Whisper STT 모델 선택 드롭다운에 `large-v3-turbo`, `large-v3`, `medium`, `small` 등이 정상 노출되는지 확인합니다.
-   - 드롭다운 하단의 캡션 텍스트에 `(Faster-Whisper 가속 모델 권장)`으로 올바르게 표시되는지 확인합니다.
-   - Gemini/Gemma 설정 드롭다운 목록에 실시간 API 조회를 통해 받아온 동적 모델 리스트가 렌더링되는지 확인합니다.
-   - 모델을 변경하고 '저장'을 누른 뒤 `data/config.json` 파일에 변경한 모델이 제대로 갱신되는지 확인합니다.
-2. **macOS 모킹(또는 실 Mac) 환경 검증**:
-   - 백엔드를 `sys.platform == 'darwin'` 조건으로 기동하거나, Mac 장비에서 설정을 띄웁니다.
-   - 드롭다운에 `mlx-community/...` 형태의 MLX 전용 모델 리스트가 표시되며, 설명에 `(MLX 최적화 모델 권장)` 문구가 나타나는지 확인합니다.
-3. **API Key 미등록/네트워크 단절 환경 검증**:
-   - `.env` 파일의 API Key를 주석 처리한 상태 또는 오프라인 상태에서 설정을 띄워도, 설정 조회 API가 안전하게 폴백 모델 목록을 즉각 응답하고 오류 화면이 발생하지 않는지 검증합니다.
+### Manual Verification
+- 테스트용 비디오 파일을 직접 컷팅하는 스크립트를 수동으로 실행해 보고, 생성된 클립 파일들의 오디오 스트림 유효성과 볼륨을 확인합니다.

--- a/services/clipper.py
+++ b/services/clipper.py
@@ -107,9 +107,9 @@ class VideoClipper:
         cmd = [
             "ffmpeg", 
             "-nostdin",
-            "-i", input_path,
             "-ss", str(start_sec),
-            "-to", str(end_sec),
+            "-t", str(duration),
+            "-i", input_path,
             "-filter_complex", f"[0:a]{audio_filter}[af]", # 오디오 필터 적용
             "-map", "0:v", "-map", "[af]",                 # 비디오는 그대로, 오디오는 필터 거친 것 사용
             "-c:v", encoder,                               # 자동 선택된 인코더

--- a/task.md
+++ b/task.md
@@ -1,6 +1,10 @@
-# 작업 추적 (Task Tracker) - develop -> main 병합
+# 동영상 구간 자르기 오디오 유실 버그 수정 작업 목록 (Task List)
 
-- [x] 로컬 `main` 브랜치(Branch) 복구 (`git reset --hard origin/main` 완료)
-- [x] `develop` -> `main` 풀 리퀘스트(Pull Request) 생성 (PR #91 완료)
-- [x] 생성된 풀 리퀘스트 병합 (PR #91 병합 완료)
-- [x] 로컬 브랜치 최신화 및 동기화 검증 (완료)
+- [x] `services/clipper.py` 내의 `cut_video` 메서드 수정 (FFmpeg 옵션 순서 및 시간 표현식 변경)
+- [x] `tests/test_clipper_audio_leak.py` 테스트 코드를 완성하여 처음 및 중간 자르기 시 오디오 보존 및 볼륨 검증
+- [x] 유닛 테스트 실행 및 검증
+  - [x] `tests/test_clipper.py` (기존 인코더 모킹 테스트)
+  - [x] `tests/test_clipper_audio_leak.py` (신규 볼륨 검증 테스트)
+- [x] `walkthrough.md` 수정 내용 반영 및 디버깅 결과 문서화
+- [/] Git 커밋 및 원격 저장소 푸시
+- [ ] GitHub PR 생성 (`develop` 브랜치 기준)

--- a/tests/test_clipper_audio_leak.py
+++ b/tests/test_clipper_audio_leak.py
@@ -1,0 +1,102 @@
+import os
+import subprocess
+import pytest
+import re
+from services.clipper import VideoClipper
+
+@pytest.mark.anyio
+async def test_multiple_exports_audio():
+    """
+    영상 처음 구간(start_time = 0.0)과 영상 중간 구간(start_time > 5.0)을 자르는 경우
+    두 클립 모두 오디오 스트림이 유실되거나 음소거(-91dB)되지 않고
+    정상적으로 소리가 포함되어 인코딩되는지 검증합니다.
+    """
+    video_dir = "static/videos"
+    video_files = [f for f in os.listdir(video_dir) if f.endswith(".mp4")]
+    assert len(video_files) > 0, "테스트용 MP4 비디오 파일이 static/videos 디렉토리에 필요합니다."
+    
+    # 테스트에 사용할 크기가 작은 영상 선택
+    test_video = None
+    for vf in video_files:
+        path = os.path.join(video_dir, vf)
+        if "Yonhapnews" in vf: # 소리가 풍부하고 확실한 뉴스 영상 우선 선택
+            test_video = path
+            break
+            
+    if not test_video:
+        for vf in video_files:
+            path = os.path.join(video_dir, vf)
+            if os.path.getsize(path) < 50 * 1024 * 1024:
+                test_video = path
+                break
+                
+    if not test_video:
+        test_video = os.path.join(video_dir, video_files[0])
+        
+    print(f"테스트 타깃 비디오: {test_video}")
+    
+    clipper = VideoClipper(temp_dir="static/temp_test")
+    
+    # 1. 처음 구간 자르기 (0.0초 ~ 5.0초)
+    out_1 = await clipper.cut_video(test_video, 0.0, 5.0, output_filename="clip_test_start.mp4")
+    assert os.path.exists(out_1), "처음 구간 잘라내기 클립이 생성되지 않았습니다."
+    
+    # 2. 중간 구간 자르기 (5.0초 ~ 10.0초)
+    out_2 = await clipper.cut_video(test_video, 5.0, 10.0, output_filename="clip_test_middle.mp4")
+    assert os.path.exists(out_2), "중간 구간 잘라내기 클립이 생성되지 않았습니다."
+    
+    # 오디오 스트림 확인 함수 (ffprobe 사용)
+    def has_audio_stream(file_path):
+        cmd = [
+            "ffprobe", 
+            "-v", "error", 
+            "-select_streams", "a", 
+            "-show_entries", "stream=codec_name", 
+            "-of", "csv=p=0", 
+            file_path
+        ]
+        result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        return len(result.stdout.strip()) > 0
+
+    # 볼륨 정보 파싱 함수 (ffmpeg volumedetect 사용)
+    def parse_max_volume(file_path):
+        cmd = [
+            "ffmpeg",
+            "-i", file_path,
+            "-filter:a", "volumedetect",
+            "-f", "null",
+            "-"
+        ]
+        result = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        # max_volume 파싱
+        max_vol = -91.0
+        for line in result.stderr.split("\n"):
+            if "max_volume:" in line:
+                match = re.search(r"max_volume:\s*([\-\d\.]+)\s*dB", line)
+                if match:
+                    max_vol = float(match.group(1))
+                    break
+        return max_vol
+
+    has_audio_1 = has_audio_stream(out_1)
+    has_audio_2 = has_audio_stream(out_2)
+    
+    vol_1 = parse_max_volume(out_1)
+    vol_2 = parse_max_volume(out_2)
+    
+    print(f"[검증 결과] 처음 구간 클립 오디오 스트림 존재: {has_audio_1}, 최대 볼륨: {vol_1} dB")
+    print(f"[검증 결과] 중간 구간 클립 오디오 스트림 존재: {has_audio_2}, 최대 볼륨: {vol_2} dB")
+    
+    # 정리
+    if os.path.exists(out_1):
+        os.remove(out_1)
+    if os.path.exists(out_2):
+        os.remove(out_2)
+        
+    assert has_audio_1, "처음 구간 클립에 오디오 스트림이 유실되었습니다."
+    assert has_audio_2, "중간 구간 클립에 오디오 스트림이 유실되었습니다."
+    
+    # 오디오 볼륨이 완벽한 무음(-91.0 dB 부근)이 아닌 실제 오디오 값이 보존되었는지 검증
+    # -60.0 dB 보다 크면 실제 음성 데이터가 유의미하게 포함된 것으로 간주합니다.
+    assert vol_1 > -60.0, f"처음 구간 클립이 음소거 상태입니다. (Volume: {vol_1} dB)"
+    assert vol_2 > -60.0, f"중간 구간 클립이 음소거 상태입니다. (Volume: {vol_2} dB)"

--- a/walkthrough.md
+++ b/walkthrough.md
@@ -1,3 +1,99 @@
+# 🎥 동영상 구간 자르기 중간 구간 오디오 유실 결함 디버깅 완료 보고서 (Walkthrough)
+
+## 1. 디버깅 관점의 문제 분석 (Debugging & Problem Analysis)
+
+### 1.1 발견된 결함 (Symptom)
+* 프론트엔드(Front-end)에서 구간 잘라내기(Export) 버튼을 통해 비디오 클립을 생성할 때, 영상의 시작점(0.0초 부근)을 포함하여 자를 때는 소리가 정상적으로 출력되지만, 영상의 중간 구간(예: 5초 이후 구간)을 잘라내면 오디오 스트림(Audio Stream) 정보는 파일 내에 존재함에도 불구하고 소리가 완전히 재생되지 않는 무음(Silent, 최대 볼륨 $-91.0\text{ dB}$) 상태가 되는 결함이 식별되었습니다.
+
+### 1.2 근본 원인 분석 (Root Cause)
+* **FFmpeg 옵션 배치 위치에 따른 타임스탬프 보존 현상**:
+  기존 `services/clipper.py`의 `cut_video` 메서드는 FFmpeg 명령어를 구성할 때 시간 탐색 옵션(`-ss`, `-to`)을 입력 파일 지정 옵션(`-i`) 뒤에 배치하였습니다.
+  ```bash
+  ffmpeg -nostdin -i <input_path> -ss <start_sec> -to <end_sec> ...
+  ```
+  이 구성은 FFmpeg에서 **출력 옵션(Output Option)**으로 작동합니다. 출력 옵션 방식은 디코더가 입력 파일 전체를 읽어가면서 구간에 도달했을 때 비로소 인코딩을 시작하도록 프레임을 선택하므로, 디코더를 빠져나온 오디오 프레임들의 타임스탬프(PTS, Presentation Timestamp)가 0으로 리셋되지 않고 **원본 영상의 타임스탬프(예: 5.0초 ~ 10.0초)를 그대로 유지**합니다.
+  
+* **오디오 페이드 필터의 입력 타임라인 일치 실패**:
+  동영상 컷팅 시 적용되는 오디오 필터는 시작/종료 시점의 오디오 노이즈 및 끊김을 방지하기 위해 다음과 같이 페이드 인/아웃 필터(`afade`)를 지정하고 있었습니다:
+  `afade=t=in:st=0:d=0.1,afade=t=out:st={duration - 0.2}:d=0.2`
+  
+  예를 들어, 5.0초~10.0초 구간을 자르고자 하는 경우 잘라낸 클립의 길이는 5초이므로 페이드 아웃 시작 시간은 `st=4.8`이 됩니다. 하지만 디코딩된 오디오 데이터의 PTS는 5.0초에서 시작합니다. 
+  `afade=t=out:st=4.8` 필터 입장에서 들어오는 모든 오디오 프레임들의 타임스탬프($\ge 5.0\text{초}$)가 페이드 아웃 임계값인 $4.8\text{초} + 0.2\text{초} = 5.0\text{초}$ 이상에 속하므로, 필터가 **모든 프레임 데이터를 완전히 감쇄(Mute, 볼륨 0)하여 출력**해 버렸던 것입니다. 0초 부근을 자를 때는 타임스탬프가 0부터 시작했기에 0~4.8초 구간의 소리가 정상 노출되었으나, 중간 구간은 항상 임계값을 넘어 소리가 유실되는 부작용이 발생했습니다.
+
+---
+
+## 2. 해결 메커니즘 (Resolution Mechanics)
+
+이 문제를 최소한의 코드 수정으로 견고하게 극복하기 위해 FFmpeg 옵션 처리 프로세스를 리팩토링하였습니다.
+
+### 2.1 주요 해결 방법
+1. **FFmpeg 옵션 배치 순서 변경 (입력 옵션으로 전환)**:
+   - `-ss` 옵션을 입력 파일 지정 옵션(`-i`) 앞으로 이동시켰습니다.
+   - `-to` 옵션 대신 잘라낼 절대적 크기(길이)를 나타내는 `-t` 옵션을 신규 도입하여 `-i` 앞으로 함께 배치하였습니다.
+   ```bash
+   ffmpeg -nostdin -ss <start_sec> -t <duration> -i <input_path> ...
+   ```
+2. **타임스탬프 리셋 효과**:
+   - `-ss`와 `-t`가 입력 파일옵션 앞에 위치하게 됨에 따라 FFmpeg는 인코딩 전 단계에서 해당 위치로 키프레임 시크를 수행하고, 지정한 길이만큼만 프레임을 디코딩합니다.
+   - 이 과정을 통해 디코더에서 나오는 비디오/오디오 프레임의 타임스탬프(PTS)가 항상 **0부터 다시 시작**하도록 보정됩니다.
+   - 결과적으로 오디오 필터 체인으로 들어오는 입력 타임라인이 오프셋 0으로 동기화되어 `afade` 필터가 정상 범위(0초 ~ duration초) 내에서 페이드 효과를 정확히 수행하게 되었으며, 오디오 유실 결함이 완전히 복구되었습니다.
+
+### 2.2 코드 변경 요약
+
+#### [services/clipper.py](file:///home/radi/cli/summarize_video/services/clipper.py)
+* `cut_video` 내의 FFmpeg 명령어 매개변수 생성 로직을 변경하였습니다.
+```python
+        # [FFmpeg Command Configuration]
+        cmd = [
+            "ffmpeg", 
+            "-nostdin",
+            "-ss", str(start_sec),
+            "-t", str(duration),
+            "-i", input_path,
+            "-filter_complex", f"[0:a]{audio_filter}[af]", # 오디오 필터 적용
+            "-map", "0:v", "-map", "[af]",                 # 비디오는 그대로, 오디오는 필터 거친 것 사용
+            "-c:v", encoder,                               # 자동 선택된 인코더
+        ]
+```
+
+---
+
+## 3. 검증 결과 (Verification Results)
+
+### 3.1 회귀 테스트 통과 (`tests/test_clipper.py`)
+* 모킹(Mocking)된 인코더 선택 로직 테스트 3개 모두 정상 통과를 완료하였습니다.
+```bash
+$ ./venv/bin/pytest tests/test_clipper.py
+============================== 3 passed in 0.03s ===============================
+```
+
+### 3.2 신규 통합 테스트 수행 및 실제 소리 검증 (`tests/test_clipper_audio_leak.py`)
+* 실제 비디오 파일을 타깃으로 삼아 처음 잘라내기(0.0초~5.0초)와 중간 구간 잘라내기(5.0초~10.0초) 시나리오를 연달아 진행하고, 생성된 클립의 소리 존재 및 최대 볼륨 상태를 FFmpeg `volumedetect` 필터로 추출 및 검증하였습니다.
+```bash
+$ ./venv/bin/pytest tests/test_clipper_audio_leak.py -s
+tests/test_clipper_audio_leak.py 테스트 타깃 비디오: static/videos/자폭드론·방공포까지…튀르키예,_대규모_합동훈련서_화력_과시__연합뉴스_(Yonhapnews).mp4
+--- [Clipper] Starting Async Cut (High Quality + Fade): clip_test_start.mp4 ---
+--- [Clipper] Cut Success: static/temp_test/clip_test_start.mp4 ---
+--- [Clipper] Starting Async Cut (High Quality + Fade): clip_test_middle.mp4 ---
+--- [Clipper] Cut Success: static/temp_test/clip_test_middle.mp4 ---
+[검증 결과] 처음 구간 클립 오디오 스트림 존재: True, 최대 볼륨: -6.8 dB
+[검증 결과] 중간 구간 클립 오디오 스트림 존재: True, 최대 볼륨: -2.9 dB
+.
+============================== 1 passed in 1.72s ===============================
+```
+* **결과 분석**: 두 결과 클립 모두 오디오 스트림이 유효하며 최대 볼륨이 무음 임계점($-60.0\text{ dB}$)보다 큰 $-6.8\text{ dB}$ 및 $-2.9\text{ dB}$로 안정적으로 인코딩 및 소리 출력이 보존됨을 성공적으로 확인하였습니다.
+
+---
+
+## 4. 교훈 및 예방 조치 (Lessons Learned)
+
+* **FFmpeg 타임스탬프와 필터 상호작용의 관계**:
+  시간적 오프셋을 매개변수로 취하는 멀티미디어 필터(예: `afade`, `overlay`, `drawtext` 등)를 설계할 때는 입력 스트림의 타임스탬프(PTS) 기준점을 명확히 알아야 합니다. 가급적 입력 옵션 방식(`-ss` / `-t`를 `-i` 앞단에 배치)을 활용하여 타임라인을 0으로 강제 리셋시키는 것이 안전합니다.
+* **실제 멀티미디어 수치 검증 자동화**:
+  단순히 파일의 존재나 스트림 헤더(Header)의 존재만 체크하는 테스트는 무음 현상과 같은 데이터 논리 오류를 잡지 못합니다. FFmpeg의 `volumedetect` 필터 등 볼륨 분석 툴을 통합 테스트에 도입해 데시벨 수치를 파싱 검증하는 기법은 향후 유사 오디오 유실 회귀를 완벽히 막아내는 견고한 장치입니다.
+
+---
+
 # 🎥 리눅스 비디오 인코더 호환성 문제 해결 및 클립 내보내기 기능 검증 완료 보고서 (Walkthrough)
 
 프론트엔드에서 영상의 구간 잘라내기(Export) 및 AI 숏츠(Shorts) 생성 요청 시 백그라운드 태스크가 실패하거나 멈추던 문제를 분석하고 해결한 상세 내용을 디버깅 관점에서 보고합니다.


### PR DESCRIPTION
## 💡 변경 사항
- FFmpeg 명령어 옵션 배치 순서를 변경하여 `-ss`와 `-t`(duration) 옵션을 입력 파일 지정 옵션인 `-i` 앞으로 위치시켰습니다.
- 이를 통해 디코더에서 추출되는 오디오 프레임의 타임스탬프(PTS)가 항상 0초부터 리셋되도록 보정함으로써, `afade` 오디오 필터 내의 페이드 아웃 시작 시점 임계값(`st=duration-0.2`)이 오작동하지 않고 온전한 구간 타임라인 내에서 작동하게 수정했습니다.
- `tests/test_clipper_audio_leak.py` 통합 테스트를 새로 개발하여, 비디오의 처음(0초) 구간과 중간 구간을 잘라냈을 때 둘 다 오디오 스트림이 유실되거나 음소거(-91dB) 상태가 되지 않고 소리가 정상 보존됨을 FFmpeg `volumedetect` 볼륨 측정 기능으로 자동 검증하도록 구축했습니다.

## 🧪 테스트 및 CI
- [x] 로컬 테스트 통과 (`tests/` 실행)
- [ ] CI 파이프라인 통과 여부 (Github Actions)
- (참고: `test_results/` 폴더는 .gitignore 처리됨)