### PR TITLE
[Fix]: Mac 환경 SSL 인증서 에러 해결

### DIFF
--- a/services/transcriber.py
+++ b/services/transcriber.py
@@ -3,6 +3,14 @@ import subprocess
 import re
 import json
 import torch
+import ssl
+import certifi
+import urllib.request
+
+# [Add] Mac 환경 SSL 인증서 에러의 근본적/보안적 해결 (certifi 사용)
+ssl_context = ssl.create_default_context(cafile=certifi.where())
+urllib.request.install_opener(urllib.request.build_opener(urllib.request.HTTPSHandler(context=ssl_context)))
+
 try:
     import mlx_whisper
 except ImportError:


### PR DESCRIPTION
## 💡 변경 사항
- Mac에서 Python 설치 방식에 따라 루트 인증서가 없어 VAD 모델 다운로드가 실패하는 문제 해결
- `certifi` 패키지를 사용하여 안전한 인증서 컨텍스트로 통신하도록 우회 처리
- 기존 코드의 구조를 건드리지 않으며 보안성을 완벽하게 유지함

## 🧪 테스트 및 CI
- [x] 로컬 테스트 통과 (`tests/` 실행)
- [ ] CI 파이프라인 통과 여부 (Github Actions)
- (참고: `test_results/` 폴더는 .gitignore 처리됨)