### PR TITLE
[Release]: develop 병합 (SSL 인증서 에러 패치 등)

### DIFF
--- a/services/transcriber.py
+++ b/services/transcriber.py
@@ -3,6 +3,14 @@ import subprocess
 import re
 import json
 import torch
+import ssl
+import certifi
+import urllib.request
+
+# [Add] Mac 환경 SSL 인증서 에러의 근본적/보안적 해결 (certifi 사용)
+ssl_context = ssl.create_default_context(cafile=certifi.where())
+urllib.request.install_opener(urllib.request.build_opener(urllib.request.HTTPSHandler(context=ssl_context)))
+
 try:
     import mlx_whisper
 except ImportError:


### PR DESCRIPTION
## 💡 변경 사항
- Mac 환경에서 SSL 인증서 문제로 발생하는 VAD 다운로드 실패 현상을 `certifi`로 해결한 패치를 메인에 릴리즈합니다.

## 🧪 테스트 및 CI
- [x] 로컬 테스트 통과
- [ ] CI 파이프라인 통과 여부