### PR TITLE
[Fix]: 하드코딩된 모델명 표기를 동적으로 변경

### DIFF
--- a/app/application/pipeline_runner.py
+++ b/app/application/pipeline_runner.py
@@ -287,7 +287,8 @@ class PipelineRunner:
         output_path = os.path.join(RESULTS_DIR, f"{base_name}_blog_view.json")
 
         try:
-            task_manager.update_progress(task_id, 0, "블로그 구조 설계 중 (Gemini 2.5 Flash-Lite)...")
+            planner_model = ConfigManager.get_model("planner")
+            task_manager.update_progress(task_id, 0, f"블로그 구조 설계 중 ({planner_model})...")
 
             if not os.path.exists(transcript_path):
                 raise FileNotFoundError("자막 데이터가 없습니다.")

--- a/services/summarizer.py
+++ b/services/summarizer.py
@@ -589,7 +589,8 @@ class VideoSummarizer:
         video_filename: str, 
         status_callback: callable = None
     ) -> dict:
-        """Gemini 2.5 Flash-Lite를 사용하여 영상 전체의 블로그 구조를 설계합니다. (Retry 적용)
+        """설정된 Planner 모델을 사용하여 영상 전체의 블로그 구조를 설계합니다. (Retry 적용)
+        기본적으로 `self._get_model("planner")`에 지정된 모델을 동적으로 사용합니다.
 
         Args:
             segments: 분석된 자막 세그먼트 리스트.
@@ -605,8 +606,9 @@ class VideoSummarizer:
         total_lines = len(segments)
         if total_lines == 0: return {"error": "Empty segments"}
 
-        print(f"--- [Summarizer] Planning Blog Structure with Gemini 2.5 Flash-Lite ---")
-        if status_callback: status_callback("Gemini 2.5 Flash-Lite가 블로그 구조를 설계 중입니다...")
+        planner_model = self._get_model("planner")
+        print(f"--- [Summarizer] Planning Blog Structure with {planner_model} ---")
+        if status_callback: status_callback(f"{planner_model}가 블로그 구조를 설계 중입니다...")
 
         # 프롬프트 구성: 전체 스크립트를 전달 (Long Context 활용)
         lines = [f"{seg['id']} | {seg['text']}" for seg in segments]
@@ -642,7 +644,7 @@ class VideoSummarizer:
 
         try:
             client = genai.Client(api_key=self.api_key)
-            # Gemini 2.5 Flash-Lite 모델 사용
+            # 동적으로 가져온 모델명 사용
             response = client.models.generate_content(
                 model=self._get_model("planner"),
                 contents=f"{system_instruction}\n\n[Full Script]:\n{script_text}",


### PR DESCRIPTION
## 💡 변경 사항
- `summarizer.py` 및 `pipeline_runner.py` 등에서 모델명을 출력할 때 하드코딩된 문자열을 제거하고, `ConfigManager`를 통해 설정된 실제 모델명을 동적으로 불러와 출력하도록 수정함.

## 🧪 테스트 및 CI
- [x] 로컬 테스트 통과
- [ ] CI 파이프라인 통과 여부